### PR TITLE
Removed crash string

### DIFF
--- a/generate_builtin_api.py
+++ b/generate_builtin_api.py
@@ -3,7 +3,6 @@ import json, os, sys
 import xml.etree.ElementTree as ET
 
 MODULE_DIR = os.getcwd()
-MODULE_DIR = "/home/geequlim/Documents/Workspace/Develop/Godot/godot/modules/ECMAScript"
 DOCS_DIR = os.path.abspath(os.path.join(MODULE_DIR, "../../doc/classes"))
 if not os.path.isdir(DOCS_DIR) and len(sys.argv) > 1:
 	DOCS_DIR = sys.argv[-1]


### PR DESCRIPTION
It prevented compilation for anyone but PC with the path from the removed string. So now it's fixed.