### PR TITLE
Implement new function

### DIFF
--- a/ecmascript.h
+++ b/ecmascript.h
@@ -41,6 +41,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	Variant _new(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 	virtual bool can_instance() const;
 
 	virtual bool inherits_script(const Ref<Script> &p_script) const { return false; }

--- a/ecmascript_binder.h
+++ b/ecmascript_binder.h
@@ -87,6 +87,7 @@ public:
 	virtual const ECMAClassInfo *parse_ecma_class(const String &p_code, const String &p_path, bool ignore_cacehe, ECMAscriptScriptError *r_error) = 0;
 	virtual const ECMAClassInfo *parse_ecma_class(const Vector<uint8_t> &p_bytecode, const String &p_path, bool ignore_cacehe, ECMAscriptScriptError *r_error) = 0;
 
+	virtual ECMAScriptGCHandler create_ecma_instance_for_godot_object_args(const ECMAClassInfo *p_class, Object *p_object, const Variant **p_args, int p_argcount) = 0;
 	virtual ECMAScriptGCHandler create_ecma_instance_for_godot_object(const ECMAClassInfo *p_class, Object *p_object) = 0;
 	virtual Variant call_method(const ECMAScriptGCHandler &p_object, const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error) = 0;
 	virtual bool get_instance_property(const ECMAScriptGCHandler &p_object, const StringName &p_name, Variant &r_ret) = 0;

--- a/quickjs/quickjs_binder.h
+++ b/quickjs/quickjs_binder.h
@@ -332,6 +332,7 @@ public:
 	virtual const ECMAClassInfo *parse_ecma_class(const Vector<uint8_t> &p_bytecode, const String &p_path, bool ignore_cacehe, ECMAscriptScriptError *r_error);
 	const ECMAClassInfo *parse_ecma_class_from_module(ModuleCache *p_module, const String &p_path, ECMAscriptScriptError *r_error);
 
+	virtual ECMAScriptGCHandler create_ecma_instance_for_godot_object_args(const ECMAClassInfo *p_class, Object *p_object, const Variant **p_args, int p_argcount);
 	virtual ECMAScriptGCHandler create_ecma_instance_for_godot_object(const ECMAClassInfo *p_class, Object *p_object);
 	virtual Variant call_method(const ECMAScriptGCHandler &p_object, const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 	virtual bool get_instance_property(const ECMAScriptGCHandler &p_object, const StringName &p_name, Variant &r_ret);


### PR DESCRIPTION
This pull request would implement the _new_ function.
This will create a more convenient API for instantiating JavaScript classes in GDScript. 

For example:

``` gdscript
var ControllerApp = preload("res://dist/GodotFreApp.jsx")

# Called when the node enters the scene tree for the first time.
func _ready():
	var x = ControllerApp.new(1, null, 'some_other_prop', self)
	add_child(x)
```

This is related to #107 

There is a few things that I am not happy about with this implementation, though.

- I created a new method for the QuickJS binder class, _create_ecma_instance_for_godot_object_args_, which is essentially a copy of _create_ecma_instance_for_godot_ except that it accepts args. Which are converted into JSValues and then passed to _JS_CallConstructor2_. I removed the _initialize_properties_ call in the new function which is used in the original function to set properties registered through _godot.register_property_. Because they are set to null when instantiating through _new()_. There probably is a better way of handling this though.
- There probably should be some error checking to see if the Godot class the JavaScript class inherits from exists in _emcascript.cpp_. 


Looking forward to review and suggestions.
