### PR TITLE
Fixed declaration file errors

### DIFF
--- a/tools/editor_tools.cpp
+++ b/tools/editor_tools.cpp
@@ -156,6 +156,7 @@ static String format_doc_text(const String &p_bbcode, const String &p_indent = "
 			line = line.replace("[constant ", "`");
 			line = line.replace("[", "`");
 			line = line.replace("]", "`");
+			line = line.replace("*/", "* /"); // To solve issues with accidental multiline comment ends
 		}
 
 		if (!in_code_block && i < lines.size() - 1) {
@@ -606,6 +607,21 @@ void ECMAScriptPlugin::_export_typescript_declare_file(const String &p_path) {
 						dict["description"] = format_doc_text(enums[i]->description, "\t\t\t ");
 						dict["name"] = format_property_name(enums[i]->name);
 						dict["value"] = enums[i]->value;
+
+						// Exceptions
+
+						/**
+						 * KEY_MASK_CMD docs has value listed as "platform-dependent",
+						 * so the actual values have to be manually changed depending on the platform.
+						 */
+						if (dict["name"] == "KEY_MASK_CMD") {
+#ifdef APPLE_STYLE_KEYS
+							dict["value"] = (1 << 27);
+#else
+							dict["value"] = (1 << 28);
+#endif
+						}
+
 						enum_str += apply_pattern(const_str, dict);
 					}
 					enum_str += "\t}\n";

--- a/tools/editor_tools.cpp
+++ b/tools/editor_tools.cpp
@@ -1,6 +1,7 @@
 #include "editor_tools.h"
 #include "../ecmascript_language.h"
 #include "core/math/expression.h"
+#include "core/os/keyboard.h"
 #include "editor/filesystem_dock.h"
 
 #define TS_IGNORE "//@ts-ignore\n"
@@ -612,14 +613,10 @@ void ECMAScriptPlugin::_export_typescript_declare_file(const String &p_path) {
 
 						/**
 						 * KEY_MASK_CMD docs has value listed as "platform-dependent",
-						 * so the actual values have to be manually changed depending on the platform.
+						 * so we have to retreive the actual value manually
 						 */
 						if (dict["name"] == "KEY_MASK_CMD") {
-#ifdef APPLE_STYLE_KEYS
-							dict["value"] = (1 << 27);
-#else
-							dict["value"] = (1 << 28);
-#endif
+							dict["value"] = KEY_MASK_CMD;
 						}
 
 						enum_str += apply_pattern(const_str, dict);


### PR DESCRIPTION
Currently, the `godot.d.ts` declaration file generated by the editor have syntax errors. These are: 

1. The term `push_*/pop` in the documentation terminating multi-line comments due to the `*/` token. This is fixed by replacing all `*/` with `* /`.

2. `KeyModifierMask.KEY_MASK_CMD` not having a value due to the doc having "platform-dependent" as a value instead of an integer. This is fixed by adding a manual check for this specific enum to replace the value with the correct one.

I'm happy to discuss alternative solutions or any other comments you might have. I also think having unit tests to detect these errors might be helpful, as future changes to the documentations could result in new errors.