### PR TITLE
Godot 4.0.0-rc compilation fixes

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -5,6 +5,7 @@ Import('env')
 Import('env_modules')
 env_module = env_modules.Clone()
 JS_ENGINE = 'quickjs'
+TOOLS = env.get('TOOLS');
 
 def open_file(path, mode):
 	if platform.python_version() > '3':
@@ -41,7 +42,7 @@ if JS_ENGINE == 'quickjs':
 	env_module.Append(CPPPATH=["quickjs/quickjs"])
 	# env_module.Append(CXXFLAGS=["-std=c++20"])
 	# env_module.Append(CCFLAGS=["-std=c++20"])
-	if env['tools']:
+	if TOOLS:
 		env_module.add_source_files(env.modules_sources, 'tools/editor_tools.cpp')
 	env_module.add_source_files(env.modules_sources, 'quickjs/quickjs_builtin_binder.gen.cpp')
 	env_module.add_source_files(env.modules_sources, 'quickjs/*.cpp')
@@ -60,7 +61,7 @@ sources = [
 	'misc/godot.binding_script.gen.cpp',
 ]
 
-if env['tools']:
+if TOOLS:
 	base_text = '/* THIS FILE IS GENERATED DO NOT EDIT */\n#include "editor_tools.h"\nString JavaScriptPlugin::{} = \n{};'
 	tool_fns = {"tools/godot.d.ts.gen.cpp": ("BUILTIN_DECLARATION_TEXT", dump_text_file_to_cpp("misc/godot.d.ts")),
 		"tools/tsconfig.json.gen.cpp": ("TSCONFIG_CONTENT", dump_text_file_to_cpp("misc/tsconfig.json")),

--- a/javascript.cpp
+++ b/javascript.cpp
@@ -23,6 +23,10 @@ bool JavaScript::can_instantiate() const {
 #endif
 }
 
+StringName JavaScript::get_global_name() const {
+	return StringName();
+}
+
 StringName JavaScript::get_instance_base_type() const {
 	static StringName empty;
 	ERR_FAIL_NULL_V(javascript_class, empty);

--- a/javascript.h
+++ b/javascript.h
@@ -43,6 +43,7 @@ public:
 	virtual Ref<Script> get_base_script() const override { return nullptr; }
 	virtual bool inherits_script(const Ref<Script> &p_script) const override { return false; }
 
+	StringName get_global_name() const override;
 	virtual StringName get_instance_base_type() const override;
 	virtual ScriptInstance *instance_create(Object *p_this) override;
 	virtual PlaceHolderScriptInstance *placeholder_instance_create(Object *p_this) override;

--- a/javascript_language.cpp
+++ b/javascript_language.cpp
@@ -18,7 +18,7 @@ static void free_callback(void *p_token, void *p_instance, void *p_binding) {
 	}
 }
 
-static GDNativeBool reference_callback(void *p_token, void *p_binding, GDNativeBool p_reference) {
+static GDExtensionBool reference_callback(void *p_token, void *p_binding, GDExtensionBool p_reference) {
 	if (JavaScriptBinder *binder = JavaScriptLanguage::get_singleton()->get_thread_binder(Thread::get_caller_id())) {
 		if (p_reference) {
 			binder->godot_refcount_incremented(static_cast<JavaScriptGCHandler *>(p_binding));

--- a/javascript_language.cpp
+++ b/javascript_language.cpp
@@ -163,7 +163,7 @@ void JavaScriptLanguage::get_reserved_words(List<String> *p_words) const {
 		"RegExp",
 		"ArrayBuffer",
 		"SharedArrayBuffer",
-		"Uint8ClampedArray"
+		"Uint8ClampedArray",
 		"Int8Array",
 		"Uint8Array",
 		"Int16Array",

--- a/javascript_language.h
+++ b/javascript_language.h
@@ -21,7 +21,7 @@ private:
 	static JavaScriptLanguage *singleton;
 	JavaScriptBinder *main_binder;
 	HashMap<Thread::ID, JavaScriptBinder *> thread_binder_map;
-	GDNativeInstanceBindingCallbacks instance_binding_callbacks;
+	GDExtensionInstanceBindingCallbacks instance_binding_callbacks;
 
 	CallableMiddleman *callable_middleman;
 #ifdef TOOLS_ENABLED
@@ -43,7 +43,7 @@ public:
 	}
 
 	_FORCE_INLINE_ virtual String get_name() const override { return "JavaScript"; }
-	const GDNativeInstanceBindingCallbacks *get_instance_binding_callbacks() const { return &instance_binding_callbacks; }
+	const GDExtensionInstanceBindingCallbacks *get_instance_binding_callbacks() const { return &instance_binding_callbacks; }
 #ifdef TOOLS_ENABLED
 	_FORCE_INLINE_ HashSet<Ref<JavaScript> > &get_scripts() { return scripts; }
 #endif

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -44,32 +44,34 @@ class EditorExportJavaScript : public EditorExportPlugin {
 
 public:
 	virtual void _export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features) override {
-		int script_mode = EditorExportPreset::MODE_SCRIPT_COMPILED;
+		String script_key;
+		// int script_mode = EditorExportPreset::MODE_SCRIPT_COMPILED;
 		const Ref<EditorExportPreset> &preset = get_export_preset();
 
-		if (preset.is_valid()) {
-			script_mode = preset->get_script_export_mode();
-		}
+		// if (preset.is_valid()) {
+		// 	script_mode = preset->get_file_export_mode(p_path);
+		// }
 
-		if (script_mode == EditorExportPreset::MODE_SCRIPT_TEXT)
-			return;
+		// if (script_mode == EditorExportPreset::MODE_SCRIPT_TEXT)
+		// 	return;
 
 		String extension = p_path.get_extension();
 		if (extension != EXT_JSCLASS && extension != EXT_JSMODULE)
 			return;
 
-		if (script_mode == EditorExportPreset::ScriptExportMode::MODE_SCRIPT_COMPILED) {
-#if 0 // Disable compile to bytecode as it is not battle tested on all platform
-			Error err;
-			String code = FileAccess::get_file_as_string(p_path, &err);
-			ERR_FAIL_COND(err != OK);
+// 		if (script_mode == EditorExportPreset::FileExportMode::MODE_SCRIPT_COMPILED) {
+// #if 0 // Disable compile to bytecode as it is not battle tested on all platform
+// 			Error err;
+// 			String code = FileAccess::get_file_as_string(p_path, &err);
+// 			ERR_FAIL_COND(err != OK);
 
-			Vector<uint8_t> file;
-			ERR_FAIL_COND(JavaScriptLanguage::get_singleton()->get_main_binder()->compile_to_bytecode(code, p_path, file) != OK);
-			add_file(p_path.get_basename() + "." + extension + "b", file, true);
-#endif
-		}
+// 			Vector<uint8_t> file;
+// 			ERR_FAIL_COND(JavaScriptLanguage::get_singleton()->get_main_binder()->compile_to_bytecode(code, p_path, file) != OK);
+// 			add_file(p_path.get_basename() + "." + extension + "b", file, true);
+// #endif
+// 		}
 	}
+	virtual String _get_name() const override { return "JavaScript"; }
 };
 
 #endif


### PR DESCRIPTION
Bare minimum fix changes following GD4 main repo changes
<br>
Includes:
- SCsub "TOOLS" var fix
- GDNative to GDExtension migration changes
- some other minor fixes

<br>

Results in:
- Compilation of gd4.0.0-rc
- working export templates


**NOTE :** These are bare minimum "just works" fixes that allow to compile the GD4 engine with ECMAScript module, please note that **I'm nowhere near a C++ dev**, these changes are to be reviewed and tested

<br>

![GD4JS-gd4](https://user-images.githubusercontent.com/18019207/220325764-dd40a4e2-2b4d-4d7f-9642-1b9022a8a93f.jpg)
