### PR TITLE
Updated JavaScript modules for Godot 4.0 branch

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -2,8 +2,8 @@ name: Build Godot
 description: Build Godot with the provided options.
 inputs:
   target:
-    description: The scons target (debug/release_debug/release).
-    default: debug
+    description: The scons target (debug/editor/release).
+    default: editor
   tools:
     description: If tools are to be built.
     default: false
@@ -20,7 +20,7 @@ inputs:
     default: ${{ github.workspace }}/.scons-cache/
   scons-cache-limit:
     description: The scons cache size limit.
-    default: 4096
+    default: 7168
   shell:
     description: the shell to run this under
     default: sh
@@ -35,7 +35,8 @@ runs:
       SCONS_CACHE_LIMIT: ${{ inputs.scons-cache-limit }}
     run: |
       echo "Building with flags:" ${{ env.SCONSFLAGS }}
-      scons p=${{ inputs.platform }} target=${{ inputs.target }} tools=${{ inputs.tools }} tests=${{ inputs.tests }} --jobs=2 ${{ env.SCONSFLAGS }}
+      if [ "${{ inputs.target }}" != "editor" ]; then rm -rf editor; fi  # Ensure we don't include editor code.
+      scons platform=${{ inputs.platform }} target=${{ inputs.target }} tools=${{ inputs.tools }} tests=${{ inputs.tests }} --jobs=2 ${{ env.SCONSFLAGS }}
       ls -l bin/
     if: inputs.shell == 'sh'
   - name: Scons Build
@@ -46,6 +47,7 @@ runs:
       SCONS_CACHE_LIMIT: ${{ inputs.scons-cache-limit }}
     run: |
       echo "Building with flags:" ${{ env.SCONSFLAGS }}
-      scons p=${{ inputs.platform }} target=${{ inputs.target }} tools=${{ inputs.tools }} tests=${{ inputs.tests }} --jobs=2 ${{ env.SCONSFLAGS }}
+      if [ "${{ inputs.target }}" != "editor" ]; then rm -rf editor; rm -rf tools; fi  # Ensure we don't include editor code.
+      scons platform=${{ inputs.platform }} target=${{ inputs.target }} tools=${{ inputs.tools }} tests=${{ inputs.tests }} --jobs=2 ${{ env.SCONSFLAGS }}
       ls -l bin/
     if: inputs.shell == 'msys2 {0}'

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -3,8 +3,8 @@ name: 🤖 Android Builds
 - push
 - pull_request
 env:
-  GODOT_BASE_BRANCH: 3.5-stable
-  SCONSFLAGS: '  verbose=yes   debug_symbols=no'
+  GODOT_BASE_BRANCH: "4.0"
+  SCONSFLAGS: verbose=yes warnings=extra debug_symbols=no module_text_server_fb_enabled=yes
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-android
   cancel-in-progress: true
@@ -21,37 +21,38 @@ jobs:
     - name: Checkout ECMAScript
       uses: actions/checkout@v2
       with:
-        path: ${{github.workspace}}/modules/ECMAScript/
+        path: ${{github.workspace}}/modules/javascript/
     - name: Make apt sources.list use the default Ubuntu repositories
       run: |
-        sudo rm -f /etc/apt/sources.list.d/*
-        sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+        # sudo rm -f /etc/apt/sources.list.d/*
+        # sudo cp -f misc/ci/sources.list /etc/apt/sources.list
         sudo apt-get update
     - name: Set up Java 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: temurin
         java-version: 11
     - name: Setup Godot build cache
       uses: ./.github/actions/godot-cache
       continue-on-error: true
     - name: Setup python and scons
-      uses: ./modules/ECMAScript/.github/actions/godot-deps
+      uses: ./modules/javascript/.github/actions/godot-deps
       with:
         shell: sh
     - name: Compilation (armv7)
-      uses: ./modules/ECMAScript/.github/actions/godot-build
+      uses: ./modules/javascript/.github/actions/godot-build
       with:
         sconsflags: ${{ env.SCONSFLAGS }} android_arch=armv7
         platform: android
-        target: release
+        target: template_release
         tools: false
         shell: sh
     - name: Compilation (arm64v8)
-      uses: ./modules/ECMAScript/.github/actions/godot-build
+      uses: ./modules/javascript/.github/actions/godot-build
       with:
         sconsflags: ${{ env.SCONSFLAGS }} android_arch=arm64v8
         platform: android
-        target: release
+        target: template_release
         tools: false
         shell: sh
     - name: Generate Godot templates

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -3,8 +3,8 @@ name: 🍏 iOS Builds
 - push
 - pull_request
 env:
-  GODOT_BASE_BRANCH: 3.5-stable
-  SCONSFLAGS: '  verbose=yes   debug_symbols=no'
+  GODOT_BASE_BRANCH: "4.0"
+  SCONSFLAGS: verbose=yes warnings=extra debug_symbols=no module_text_server_fb_enabled=yes
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-ios
   cancel-in-progress: true
@@ -21,20 +21,20 @@ jobs:
     - name: Checkout ECMAScript
       uses: actions/checkout@v2
       with:
-        path: ${{github.workspace}}/modules/ECMAScript/
+        path: ${{github.workspace}}/modules/javascript/
     - name: Setup Godot build cache
       uses: ./.github/actions/godot-cache
       continue-on-error: true
     - name: Setup python and scons
-      uses: ./modules/ECMAScript/.github/actions/godot-deps
+      uses: ./modules/javascript/.github/actions/godot-deps
       with:
         shell: sh
     - name: Compilation (armv7)
-      uses: ./modules/ECMAScript/.github/actions/godot-build
+      uses: ./modules/javascript/.github/actions/godot-build
       with:
         sconsflags: ${{ env.SCONSFLAGS }}
-        platform: iphone
-        target: release
+        platform: ios
+        target: template_release
         tools: false
         shell: sh
     - name: Upload artifact

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -3,10 +3,11 @@ name: 🌐 JavaScript Builds
 - push
 - pull_request
 env:
-  GODOT_BASE_BRANCH: 3.5-stable
-  SCONSFLAGS: '  verbose=yes   debug_symbols=no'
-  EM_VERSION: 2.0.25
-  EM_CACHE_FOLDER: emsdk-cache
+  GODOT_BASE_BRANCH: "4.0"
+  SCONSFLAGS: verbose=yes warnings=extra debug_symbols=no
+  EM_VERSION: 3.1.18
+  EM_CACHE_FOLDER: "emsdk-cache"
+
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-javascript
   cancel-in-progress: true
@@ -23,7 +24,7 @@ jobs:
     - name: Checkout ECMAScript
       uses: actions/checkout@v2
       with:
-        path: ${{github.workspace}}/modules/ECMAScript/
+        path: ${{github.workspace}}/modules/javascript/
     - name: Load Emscripten cache
       id: javascript-template-emscripten-cache
       uses: actions/cache@v2
@@ -31,7 +32,7 @@ jobs:
         path: ${{env.EM_CACHE_FOLDER}}
         key: ${{env.EM_VERSION}}-${{github.job}}
     - name: Set up Emscripten latest
-      uses: mymindstorm/setup-emsdk@v10
+      uses: mymindstorm/setup-emsdk@v12
       with:
         version: ${{env.EM_VERSION}}
         actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
@@ -42,16 +43,16 @@ jobs:
       uses: ./.github/actions/godot-cache
       continue-on-error: true
     - name: Setup python and scons
-      uses: ./modules/ECMAScript/.github/actions/godot-deps
+      uses: ./modules/javascript/.github/actions/godot-deps
       with:
         shell: sh
     - name: Compilation
-      uses: ./modules/ECMAScript/.github/actions/godot-build
+      uses: ./modules/javascript/.github/actions/godot-build
       with:
         sconsflags: ${{ env.SCONSFLAGS }}
-        platform: javascript
-        target: release
-        tools: false
+        platform: web
+        target: template_release
+        tools: falsed
         shell: sh
     - name: Upload artifact
       uses: ./.github/actions/upload-artifact

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -3,8 +3,11 @@ name: 🐧 Linux Builds
 - push
 - pull_request
 env:
-  GODOT_BASE_BRANCH: 3.5-stable
-  SCONSFLAGS: '  verbose=yes  '
+  GODOT_BASE_BRANCH: "4.0"
+  SCONSFLAGS: '  verbose=yes warnings=extra module_text_server_fb_enabled=yes  '
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux
   cancel-in-progress: true
@@ -16,30 +19,44 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Editor w/ Mono (target=release_debug, tools=yes)
+        - name: Editor w/ Mono (target=editor, tools=yes)
           cache-name: linux-editor-mono
-          target: release_debug
+          target: editor
+          tests: false # Disabled due freeze caused by mix Mono build and CI
           tools: true
-          sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
-          bin: ./bin/godot.x11.opt.tools.64.mono
+          sconsflags: module_mono_enabled=yes
+          doc-test: true
+          bin: "./bin/godot.linuxbsd.editor.x86_64.mono"
           build-mono: true
+          proj-conv: true
           artifact: true
-        - name: Editor and sanitizers (target=debug, tools=yes)
-          cache-name: linux-editor-sanitizers
-          target: debug
-          tools: true
-          sconsflags: ' '
-          test: true
-          bin: ./bin/godot.x11.tools.64s
+        - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold)
+          cache-name: linux-editor-double-sanitizers
+          target: editor
+          tests: true
+          # Debug symbols disabled as they're huge on this build and we hit the 14 GB limit for runners.
+          sconsflags: dev_build=yes debug_symbols=no precision=double use_asan=yes use_ubsan=yes linker=gold
+          proj-test: true
+          # Can be turned off for PRs that intentionally break compat with godot-cpp,
+          # until both the upstream PR and the matching godot-cpp changes are merged.
+          godot-cpp-test: true
+          bin: "./bin/godot.linuxbsd.editor.dev.double.x86_64.san"
           build-mono: false
+          # Skip 2GiB artifact speeding up action.
           artifact: false
-        - name: Template w/ Mono (target=release, tools=no)
+        - name: Template w/ Mono (target=template_release)
           cache-name: linux-template-mono
-          target: release
-          tools: false
-          sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no debug_symbols=no
+          target: template_release
+          tests: false
+          sconsflags: module_mono_enabled=yes
           build-mono: false
           artifact: true
+
+        - name: Minimal template (target=template_release, everything disabled)
+          cache-name: linux-template-minimal
+          target: template_release
+          tests: false
+          sconsflags: modules_enabled_by_default=no disable_3d=yes disable_advanced_gui=yes deprecated=no 
     steps:
     - name: Checkout Godot
       uses: actions/checkout@v2
@@ -49,13 +66,20 @@ jobs:
     - name: Checkout ECMAScript
       uses: actions/checkout@v2
       with:
-        path: ${{github.workspace}}/modules/ECMAScript/
+        path: ${{github.workspace}}/modules/javascript/
+    # Need newer mesa for lavapipe to work properly.
+    - name: Linux dependencies for tests
+      if: ${{ matrix.proj-test }}
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+        sudo add-apt-repository ppa:kisak/kisak-mesa
+        sudo apt-get install -qq mesa-vulkan-drivers
     - name: Linux dependencies
       shell: bash
       run: |
         # Azure repositories are not reliable, we need to prevent azure giving us packages.
-        sudo rm -f /etc/apt/sources.list.d/*
-        sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+        # sudo rm -f /etc/apt/sources.list.d/*
+        # sudo cp -f misc/ci/sources.list /etc/apt/sources.list
         sudo apt-get update
         # The actual dependencies
         sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
@@ -67,57 +91,126 @@ jobs:
         cache-name: ${{ matrix.cache-name }}
       continue-on-error: true
     - name: Setup python and scons
-      uses: ./modules/ECMAScript/.github/actions/godot-deps
+      uses: ./modules/javascript/.github/actions/godot-deps
       with:
         shell: sh
+
+    - name: Set up .NET Sdk
+      uses: actions/setup-dotnet@v2
+      if: ${{ matrix.build-mono }}
+      with:
+        dotnet-version: '6.0.x'
+
+    - name: Setup GCC problem matcher
+      uses: ammaraskar/gcc-problem-matcher@master
+
     - name: Compilation
-      uses: ./modules/ECMAScript/.github/actions/godot-build
+      uses: ./modules/javascript/.github/actions/godot-build
       with:
         sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
         platform: linuxbsd
         target: ${{ matrix.target }}
         tools: ${{ matrix.tools }}
+        tests: ${{ matrix.tests }}
         shell: sh
-    - name: Generate Mono glue code
+
+    - name: Generate C# glue
       if: ${{ matrix.build-mono }}
       run: |
-        DRI_PRIME=0 xvfb-run ${{ matrix.bin }} --generate-mono-glue modules/mono/glue || true
-    - name: Compilation (mono_glue=yes)
-      uses: ./modules/ECMAScript/.github/actions/godot-build
+        ${{ matrix.bin }} --headless --generate-mono-glue ./modules/mono/glue || true
+
+    - name: Build .NET solutions
       if: ${{ matrix.build-mono }}
-      with:
-        sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }} mono_glue=yes
-        platform: linuxbsd
-        target: ${{ matrix.target }}
-        tools: ${{ matrix.tools }}
-        shell: sh
-    - name: Download test project
-      if: ${{ matrix.test }}
       run: |
-        wget https://github.com/godotengine/regression-test-project/archive/3.4.zip
-        unzip 3.4.zip
-        mv "regression-test-project-3.4" "test_project"
-    - name: Open and close editor
-      if: ${{ matrix.test }}
+        ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
+
+    # Execute unit tests for the editor
+    - name: Unit tests
+      if: ${{ matrix.tests }}
       run: |
-        DRI_PRIME=0 xvfb-run ${{ matrix.bin }} --audio-driver Dummy -e -q --path test_project 2>&1 | tee sanitizers_log.txt || true
-        misc/scripts/check_ci_log.py sanitizers_log.txt
-    - name: Run project
-      if: ${{ matrix.test }}
-      run: |
-        DRI_PRIME=0 xvfb-run ${{ matrix.bin }} 30 --video-driver GLES3 --audio-driver Dummy --path test_project 2>&1 | tee sanitizers_log.txt || true
-        misc/scripts/check_ci_log.py sanitizers_log.txt
-    - name: Check for class reference updates
-      if: ${{ matrix.test }}
-      run: |
-        echo "Running --doctool to see if this changes the public API without updating the documentation."
-        echo -e "If a diff is shown, it means that your code/doc changes are incomplete and you should update the class reference with --doctool.\n\n"
-        DRI_PRIME=0 xvfb-run ${{ matrix.bin }} --doctool . 2>&1 > /dev/null || true
-        git diff --color --exit-code && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'
+        ${{ matrix.bin }} --version
+        ${{ matrix.bin }} --help
+        ${{ matrix.bin }} --test --headless
+
+    # Check class reference
+    # - name: Check for class reference updates
+    #   if: ${{ matrix.doc-test }}
+    #   run: |
+    #     echo "Running --doctool to see if this changes the public API without updating the documentation."
+    #     echo -e "If a diff is shown, it means that your code/doc changes are incomplete and you should update the class reference with --doctool.\n\n"
+    #     ${{ matrix.bin }} --doctool --headless 2>&1 > /dev/null || true
+    #     git diff --color --exit-code && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'
+
+    # Test 3.x -> 4.x project converter
+    # - name: Test project converter
+    #   if: ${{ matrix.proj-conv }}
+    #   run: |
+    #     mkdir converter_test
+    #     cd converter_test
+    #     touch project.godot
+    #     ../${{ matrix.bin }} --headless --validate-conversion-3to4
+    #     cd ..
+    #     rm converter_test -rf
+
+    # # Download and extract zip archive with project, folder is renamed to be able to easy change used project
+    # - name: Download test project
+    #   if: ${{ matrix.proj-test }}
+    #   run: |
+    #     wget https://github.com/godotengine/regression-test-project/archive/4.0.zip
+    #     unzip 4.0.zip
+    #     mv "regression-test-project-4.0" "test_project"
+
+    # # Editor is quite complicated piece of software, so it is easy to introduce bug here
+    # - name: Open and close editor (Vulkan)
+    #   if: ${{ matrix.proj-test }}
+    #   run: |
+    #     xvfb-run ${{ matrix.bin }} --audio-driver Dummy --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
+    #     misc/scripts/check_ci_log.py sanitizers_log.txt
+
+    # - name: Open and close editor (GLES3)
+    #   if: ${{ matrix.proj-test }}
+    #   run: |
+    #     DRI_PRIME=0 xvfb-run ${{ matrix.bin }} --audio-driver Dummy --rendering-driver opengl3 --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
+    #     misc/scripts/check_ci_log.py sanitizers_log.txt
+
+    # # Run test project
+    # - name: Run project
+    #   if: ${{ matrix.proj-test }}
+    #   run: |
+    #     xvfb-run ${{ matrix.bin }} 40 --audio-driver Dummy --path test_project 2>&1 | tee sanitizers_log.txt || true
+    #     misc/scripts/check_ci_log.py sanitizers_log.txt
+
+    # # Checkout godot-cpp
+    # - name: Checkout godot-cpp
+    #   if: ${{ matrix.godot-cpp-test }}
+    #   uses: actions/checkout@v3
+    #   with:
+    #     repository: godotengine/godot-cpp
+    #     submodules: 'recursive'
+    #     path: 'godot-cpp'
+
+    # # Dump GDExtension interface and API
+    # - name: Dump GDExtension interface and API for godot-cpp build
+    #   if: ${{ matrix.godot-cpp-test }}
+    #   run: |
+    #     ${{ matrix.bin }} --headless --dump-gdextension-interface --dump-extension-api
+    #     cp -f gdextension_interface.h godot-cpp/gdextension/
+    #     cp -f extension_api.json godot-cpp/gdextension/
+
+    # # Build godot-cpp test extension
+    # - name: Build godot-cpp test extension
+    #   if: ${{ matrix.godot-cpp-test }}
+    #   run: |
+    #     cd godot-cpp/test
+    #     scons target=template_debug dev_build=yes
+    #     cd ../..
+
     - name: Prepare artifact
       if: ${{ matrix.artifact }}
       run: |
         strip bin/godot.*
+        chmod +x bin/godot.*
+
     - name: Upload artifact
       uses: ./.github/actions/upload-artifact
       if: ${{ matrix.artifact }}

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -3,8 +3,8 @@ name: 🍎 macOS Builds
 - push
 - pull_request
 env:
-  GODOT_BASE_BRANCH: 3.5-stable
-  SCONSFLAGS: '  verbose=yes   debug_symbols=no'
+  GODOT_BASE_BRANCH: "4.0"
+  SCONSFLAGS: verbose=yes warnings=extra module_text_server_fb_enabled=yes
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos
   cancel-in-progress: true
@@ -16,14 +16,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Editor (target=release_debug, tools=yes)
+        - name: Editor (target=editor, tools=yes)
           cache-name: macos-editor
-          target: release_debug
+          target: editor
           tools: true
+          tests: false
           bin: ./bin/godot.osx.opt.tools.64
         - name: Template (target=release, tools=no)
           cache-name: macos-template
-          target: release
+          target: template_release
+          tests: false
+          sconsflags: debug_symbols=no
           tools: false
     steps:
     - name: Checkout Godot
@@ -34,24 +37,42 @@ jobs:
     - name: Checkout ECMAScript
       uses: actions/checkout@v2
       with:
-        path: ${{github.workspace}}/modules/ECMAScript/
+        path: ${{github.workspace}}/modules/javascript/
     - name: Setup Godot build cache
       uses: ./.github/actions/godot-cache
       with:
         cache-name: ${{ matrix.cache-name }}
       continue-on-error: true
     - name: Setup python and scons
-      uses: ./modules/ECMAScript/.github/actions/godot-deps
+      uses: ./modules/javascript/.github/actions/godot-deps
       with:
         shell: sh
+    - name: Setup Vulkan SDK
+      run: |
+        sh misc/scripts/install_vulkan_sdk_macos.sh
     - name: Compilation
-      uses: ./modules/ECMAScript/.github/actions/godot-build
+      uses: ./modules/javascript/.github/actions/godot-build
       with:
         sconsflags: ${{ env.SCONSFLAGS }}
-        platform: osx
+        platform: macos
         target: ${{ matrix.target }}
+        tests: ${{ matrix.tests }}
         tools: ${{ matrix.tools }}
         shell: sh
+
+    # Execute unit tests for the editor
+    - name: Unit tests
+      if: ${{ matrix.tests }}
+      run: |
+        ${{ matrix.bin }} --version
+        ${{ matrix.bin }} --help
+        ${{ matrix.bin }} --test
+
+    - name: Prepare artifact
+      run: |
+        strip bin/godot.*
+        chmod +x bin/godot.*
+
     - name: Upload artifact
       uses: ./.github/actions/upload-artifact
       with:

--- a/.github/workflows/server_builds.yml
+++ b/.github/workflows/server_builds.yml
@@ -3,9 +3,11 @@ name: ☁ Server Builds
 - push
 - pull_request
 env:
-  GODOT_BASE_BRANCH: 3.5-stable
-  SCONSFLAGS: '  verbose=yes   debug_symbols=no module_mono_enabled=yes mono_static=yes
-    mono_glue=no'
+  GODOT_BASE_BRANCH: "4.0"
+  SCONSFLAGS: '  verbose=yes warnings=extra module_text_server_fb_enabled=yes  '
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-server
   cancel-in-progress: true
@@ -17,14 +19,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Linux Headless w/ Mono (target=release_debug, tools=yes)
+        - name: Linux Headless w/ Mono (target=editor, tools=yes)
           cache-name: server-editor-mono
-          target: release_debug
+          target: editor
+          tests: false # Disabled due freeze caused by mix Mono build and CI
           tools: true
+          sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
+          bin: ./bin/godot.x11.opt.tools.64.mono
+          build-mono: true
+          artifact: true
         - name: Linux Server w/ Mono (target=release, tools=no)
           cache-name: server-template-mono
-          target: release
+          target: template_release
+          tests: false # Disabled due freeze caused by mix Mono build and CI
           tools: false
+          sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
+          build-mono: true
+          artifact: true
     steps:
     - name: Checkout Godot
       uses: actions/checkout@v2
@@ -34,13 +45,13 @@ jobs:
     - name: Checkout ECMAScript
       uses: actions/checkout@v2
       with:
-        path: ${{github.workspace}}/modules/ECMAScript/
+        path: ${{github.workspace}}/modules/javascript/
     - name: Linux dependencies
       shell: bash
       run: |
         # Azure repositories are not reliable, we need to prevent azure giving us packages.
-        sudo rm -f /etc/apt/sources.list.d/*
-        sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+        # sudo rm -f /etc/apt/sources.list.d/*
+        # sudo cp -f misc/ci/sources.list /etc/apt/sources.list
         sudo apt-get update
         # The actual dependencies
         sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
@@ -52,14 +63,14 @@ jobs:
         cache-name: ${{ matrix.cache-name }}
       continue-on-error: true
     - name: Setup python and scons
-      uses: ./modules/ECMAScript/.github/actions/godot-deps
+      uses: ./modules/javascript/.github/actions/godot-deps
       with:
         shell: sh
     - name: Compilation
-      uses: ./modules/ECMAScript/.github/actions/godot-build
+      uses: ./modules/javascript/.github/actions/godot-build
       with:
         sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
-        platform: server
+        platform: linuxbsd
         target: ${{ matrix.target }}
         tools: ${{ matrix.tools }}
         shell: sh

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -3,8 +3,8 @@ name: 🏁 Windows Builds
 - push
 - pull_request
 env:
-  GODOT_BASE_BRANCH: 3.5-stable
-  SCONSFLAGS: '  use_mingw=yes  verbose=yes   debug_symbols=no'
+  GODOT_BASE_BRANCH: "4.0"
+  SCONSFLAGS: '  use_mingw=yes  debug_symbols=no verbose=yes warnings=extra module_text_server_fb_enabled=yes'
   SCONS_CACHE_MSVC_CONFIG: true
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-windows
@@ -17,15 +17,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Editor (target=release_debug, tools=yes)
+        - name: Editor (target=editor, tools=yes)
           cache-name: windows-editor
-          target: release_debug
+          target: editor
+          tests: false
           tools: true
           bin: ./bin/godot.windows.opt.tools.64.exe
         - name: Template (target=release, tools=no)
           cache-name: windows-template
-          target: release
+          target: template_release
           tools: false
+          tests: false
+          sconsflags: debug_symbols=no
     steps:
     - name: setup-msys2
       uses: msys2/setup-msys2@v2
@@ -46,22 +49,27 @@ jobs:
     - name: Checkout ECMAScript
       uses: actions/checkout@v2
       with:
-        path: ${{github.workspace}}/modules/ECMAScript/
+        path: ${{github.workspace}}/modules/javascript/
     - name: Setup Godot build cache
       uses: ./.github/actions/godot-cache
       with:
         cache-name: ${{ matrix.cache-name }}
       continue-on-error: true
     - name: Setup python and scons
-      uses: ./modules/ECMAScript/.github/actions/godot-deps
+      uses: ./modules/javascript/.github/actions/godot-deps
       with:
         shell: msys2 {0}
+
+    - name: Setup MSVC problem matcher
+      uses: ammaraskar/msvc-problem-matcher@master
+
     - name: Compilation
-      uses: ./modules/ECMAScript/.github/actions/godot-build
+      uses: ./modules/javascript/.github/actions/godot-build
       with:
-        sconsflags: ${{ env.SCONSFLAGS }}
+        sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
         platform: windows
         target: ${{ matrix.target }}
+        tests: ${{ matrix.tests }}
         tools: ${{ matrix.tools }}
         scons-cache-limit: 3072
         shell: msys2 {0}

--- a/SCsub
+++ b/SCsub
@@ -5,7 +5,7 @@ Import('env')
 Import('env_modules')
 env_module = env_modules.Clone()
 JS_ENGINE = 'quickjs'
-TOOLS = env.get('TOOLS');
+TOOLS = ('editor' == env_module['target']) #env.get('TOOLS');
 
 def open_file(path, mode):
 	if platform.python_version() > '3':
@@ -36,7 +36,7 @@ if JS_ENGINE == 'quickjs':
 	version = open('quickjs/quickjs/VERSION.txt', 'r').read().split('\n')[0]
 	env_module.Append(CPPDEFINES={"QUICKJS_CONFIG_VERSION": '"'+ version +'"'})
 	env_module.Append(CPPDEFINES=["CONFIG_BIGNUM"])
-	if env_module['target'] != 'release':
+	if 'release' not in (env_module['target'] or ''):
 		env_module.Append(CPPDEFINES={"DUMP_LEAKS": 1})
 		env_module.Append(CPPDEFINES={"QUICKJS_WITH_DEBUGGER": 1})
 	env_module.Append(CPPPATH=["quickjs/quickjs"])

--- a/build_github_actions.py
+++ b/build_github_actions.py
@@ -4,7 +4,7 @@ run this every time you upgrade the godot-base version to generate new matching 
 You must be in this directory, and in the modules subfolder of godot (just as if you would install this project into godot)
 
 usage:
-python build_github_actions.py --godot-version "3.5-stable" --godot-github-folder ../../.github --js-github-folder .github
+python build_github_actions.py --godot-version "4.0" --godot-github-folder ../../.github --js-github-folder .github
 
 """
 

--- a/javascript_language.h
+++ b/javascript_language.h
@@ -54,7 +54,7 @@ public:
 
 	virtual void init() override;
 	virtual void finish() override;
-	virtual Error execute_file(const String &p_path) override;
+	virtual Error execute_file(const String &p_path);
 
 	virtual void get_reserved_words(List<String> *p_words) const override;
 	virtual bool is_control_flow_keyword(String p_keywords) const override;

--- a/quickjs/quickjs_callable.h
+++ b/quickjs/quickjs_callable.h
@@ -2,7 +2,11 @@
 #define QUICKJS_CALLABLE_H
 #include "../javascript_callable.h"
 #include "quickjs/quickjs.h"
+
+#if !defined(JS_NAN_BOXING)
+///typedef uint64_t JSValue; defined in quickjs.h if defined(JS_NAN_BOXING)
 struct JSValue;
+#endif
 
 class QuickJSCallable : public JavaScriptCallable {
 	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);


### PR DESCRIPTION
The commits address various issues, such as non-existent files, editor targets, module usage, and compilation errors. The messages also show an effort to align the project's GitHub actions with the main Godot repository and tackle platform-specific problems. Some commits address challenges related to advanced Linux builds and temporarily disable the "-werror" flag due to issues with QuickJS.

Replaces https://github.com/Geequlim/ECMAScript/pull/149