### PR TITLE
Support for StringName

### DIFF
--- a/generate_builtin_api.py
+++ b/generate_builtin_api.py
@@ -54,6 +54,7 @@ TYPE_MAP = {
     "bool": "boolean",
     "String": "string",
     "NodePath": "string",
+    "StringName": "string",
 }
 
 METHOD_OP_EQUALS = {

--- a/thirdparty/quickjs/quickjs_binder.cpp
+++ b/thirdparty/quickjs/quickjs_binder.cpp
@@ -241,6 +241,7 @@ JSValue QuickJSBinder::variant_to_var(JSContext *ctx, const Variant p_var) {
 		case Variant::FLOAT:
 			return JS_NewFloat64(ctx, (double)(p_var));
 		case Variant::NODE_PATH:
+		case Variant::STRING_NAME:
 		case Variant::STRING:
 			return to_js_string(ctx, p_var);
 		case Variant::OBJECT: {

--- a/tools/editor_tools.cpp
+++ b/tools/editor_tools.cpp
@@ -233,7 +233,7 @@ static String get_type_name(const String &p_type) {
 		return "number";
 	if (p_type == "bool")
 		return "boolean";
-	if (p_type == "String" || p_type == "NodePath")
+	if (p_type == "String" || p_type == "NodePath" || p_type == "StringName")
 		return "string";
 	if (p_type == "Array")
 		return "any[]";


### PR DESCRIPTION
Allows godot functions that return StringNames to work, useful for a tool I'm working on to give back cool auto-complet-ey typescript types from scenes/nodes