### PR TITLE
docs: add correct godot version for "Compiling from source"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#  GodotJS - JavaScript language binding for Godot game engine
+# GodotJS - JavaScript language binding for Godot game engine
 
 This module implements JavaScript/TypeScript language support for the Godot game engine using [QuickJS](https://bellard.org/quickjs/) as the JavaScript engine.
 
@@ -22,23 +22,28 @@ Read the [getting-started](https://geequlim.github.io/ECMAScript/getting-started
 No installation or setup necessary. The binaries for download are the complete, usable Godot editor and engine with JavaScript/TypeScript language support.
 
 ### Binary downloads
+
 Download the binaries from the [release page](https://github.com/GodotExplorer/ECMAScript/releases).
 
 ### Compiling from source
-- Clone the source code of [godot](https://github.com/godotengine/godot): 
-  - ``git clone git@github.com:godotengine/godot.git``  or
-  - ``git clone https://github.com/godotengine/godot.git``
-- Clone this module and put it into `godot/modules/javascript`: 
-	- ``git clone git@github.com:Geequlim/ECMAScript.git godot/modules/javascript``  or
-	- ``git clone https://github.com/Geequlim/ECMAScript.git godot/modules/javascript``
-- [Recompile the godot engine](https://docs.godotengine.org/en/4.1/development/compiling/index.html) 
-  - Use ``scons`` with those additional options ``warnings=extra werror=yes module_text_server_fb_enabled=yes`` to show all potential errors
+
+- Clone the source code of [godot](https://github.com/godotengine/godot):
+  - `git clone git@github.com:godotengine/godot.git` or
+  - `git clone https://github.com/godotengine/godot.git`
+- This branch uses version `4.1` so checkout the version with: `git checkout 4.1`
+- Clone this module and put it into `godot/modules/javascript`:
+  - `git clone git@github.com:Geequlim/ECMAScript.git godot/modules/javascript` or
+  - `git clone https://github.com/Geequlim/ECMAScript.git godot/modules/javascript`
+- [Recompile the godot engine](https://docs.godotengine.org/en/4.1/development/compiling/index.html)
+  - Use `scons` with those additional options `warnings=extra werror=yes module_text_server_fb_enabled=yes` to show all potential errors:
+    - Windows: `scons platform=windows warnings=extra werror=yes module_text_server_fb_enabled=yes`
+    - MacOS: `scons platform=macos arch=arm64 warnings=extra werror=yes module_text_server_fb_enabled=yes`
 
 ## Documentation, Tutorials & Demos
 
 Read this [documentation](https://geequlim.github.io/ECMAScript/getting-started) or look at the tutorials or demos:
 
-
 - [ECMAScriptDemos](https://github.com/Geequlim/ECMAScriptDemos) - Demos
 - [godot-ECMAScript-cookbook](https://github.com/why-try313/godot-ECMAScript-cookbook/wiki) - Tutorial
 - [godot-typescript-starter](https://github.com/citizenll/godot-typescript-starter) - Template
+- [godot-js-template](https://github.com/fukaraadam-workspace/godot-js-template) - Template

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-#  GodotJS - JavaScript language binding for Godot game engine
+# GodotJS - JavaScript language binding for Godot game engine
 
 This module implements JavaScript/TypeScript language support for the Godot game engine using [QuickJS](https://bellard.org/quickjs/) as the JavaScript engine.
 
@@ -15,30 +15,35 @@ This module implements JavaScript/TypeScript language support for the Godot game
 
 ### Getting started
 
-Read the [getting-started](https://geequlim.github.io/ecmascript/getting-started).
+Read the [getting-started](https://geequlim.github.io/ECMAScript/getting-started).
 
 ## Getting the engine
 
 No installation or setup necessary. The binaries for download are the complete, usable Godot editor and engine with JavaScript/TypeScript language support.
 
 ### Binary downloads
+
 Download the binaries from the [release page](https://github.com/GodotExplorer/ECMAScript/releases).
 
 ### Compiling from source
+
 - Clone the source code of [godot](https://github.com/godotengine/godot):
-	- ``git clone git@github.com:godotengine/godot.git``  or
-	- ``git clone https://github.com/godotengine/godot.git``
+  - `git clone git@github.com:godotengine/godot.git` or
+  - `git clone https://github.com/godotengine/godot.git`
+- This branch uses version `4.1` so checkout the version with: `git checkout 4.1`
 - Clone this module and put it into `godot/modules/javascript`:
-	- ``git clone git@github.com:Geequlim/ECMAScript.git godot/modules/javascript``  or
-	- ``git clone https://github.com/Geequlim/ECMAScript.git godot/modules/javascript``
+  - `git clone git@github.com:Geequlim/ECMAScript.git godot/modules/javascript` or
+  - `git clone https://github.com/Geequlim/ECMAScript.git godot/modules/javascript`
 - [Recompile the godot engine](https://docs.godotengine.org/en/4.1/development/compiling/index.html)
-	- Use ``scons`` with those additional options ``warnings=extra werror=yes module_text_server_fb_enabled=yes`` to show all potential errors
+  - Use `scons` with those additional options `warnings=extra werror=yes module_text_server_fb_enabled=yes` to show all potential errors:
+    - Windows: `scons platform=windows warnings=extra werror=yes module_text_server_fb_enabled=yes`
+    - MacOS: `scons platform=macos arch=arm64 warnings=extra werror=yes module_text_server_fb_enabled=yes`
 
 ## Documentation, Tutorials & Demos
 
-Read this [documentation](https://geequlim.github.io/ecmascript/) or look at the tutorials or demos:
+Read this [documentation](https://geequlim.github.io/ECMAScript/getting-started) or look at the tutorials or demos:
 
-
-- [ECMAScriptDemos](https://github.com/Geequlim/ECMAScriptDemos)
-- [godot-ECMAScript-cookbook](https://github.com/why-try313/godot-ECMAScript-cookbook/wiki)
-- [godot-typescript-starter](https://github.com/citizenll/godot-typescript-starter)
+- [ECMAScriptDemos](https://github.com/Geequlim/ECMAScriptDemos) - Demos
+- [godot-ECMAScript-cookbook](https://github.com/why-try313/godot-ECMAScript-cookbook/wiki) - Tutorial
+- [godot-typescript-starter](https://github.com/citizenll/godot-typescript-starter) - Template
+- [godot-js-template](https://github.com/fukaraadam-workspace/godot-js-template) - Template


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Add `git checkout` with correct godot version to compile from source