### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows"

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -60,33 +60,13 @@ jobs:
         run: |
           sh misc/scripts/install_vulkan_sdk_macos.sh
 
-      - name: Compilation (x86_64)
+      - name: Compilation
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=x86_64
+          sconsflags: ${{ env.SCONSFLAGS }}
           platform: macos
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
-
-      - name: Compilation (arm64)
-        uses: ./.github/actions/godot-build
-        with:
-          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
-          platform: macos
-          target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
-
-      - name: Prepare artifact
-        run: |
-          lipo -create ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64 -output ./bin/godot.macos.${{ matrix.target }}.universal
-          rm ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64
-          strip bin/godot.*
-          chmod +x bin/godot.*
-
-      - name: Upload artifact
-        uses: ./.github/actions/upload-artifact
-        with:
-          name: ${{ matrix.cache-name }}
 
       # Execute unit tests for the editor
       - name: Unit tests
@@ -94,4 +74,14 @@ jobs:
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help
-          ${{ matrix.bin }} --test --force-colors
+          ${{ matrix.bin }} --test
+
+      - name: Prepare artifact
+        run: |
+          strip bin/godot.*
+          chmod +x bin/godot.*
+
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        with:
+          name: ${{ matrix.cache-name }}

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ⏬ Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}


### PR DESCRIPTION
Reverts Geequlim/ECMAScript#196