### PR TITLE
fix: issue with !is_inside_tree() when starting editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .vscode
 .idea
 /site
+venv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,6 @@ As a maintainer you are able to create a new release.
 3. Select target ``master``
 4. Click ``Generate release notes``
 5. (Optional) You can edit the generated release notes
-6. Add a release title in the format ``[Godot_Version]-[Tag]-alpha-[Year][Month][Day]`` as an example ``4.1-v0.0.17-alpha-20231003``
+6. Add a release title in the format ``[Tag]-alpha-[Year][Month][Day]`` as an example ``v0.0.17-alpha-20231003``. The used godot version will be added ass prefix automatically
 7. Press ``Publish release``
 

--- a/editor/editor_tools.cpp
+++ b/editor/editor_tools.cpp
@@ -80,7 +80,6 @@ JavaScriptPlugin::JavaScriptPlugin(EditorNode *p_node) {
 	declaration_file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	declaration_file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	declaration_file_dialog->add_filter(TTR("*.d.ts;TypeScript Declaration file"));
-	declaration_file_dialog->set_current_file("godot.d.ts");
 	declaration_file_dialog->connect("file_selected", callable_mp(this, &JavaScriptPlugin::_export_typescript_declare_file));
 	EditorNode::get_singleton()->get_gui_base()->add_child(declaration_file_dialog);
 
@@ -89,7 +88,6 @@ JavaScriptPlugin::JavaScriptPlugin(EditorNode *p_node) {
 	enumberation_file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	enumberation_file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	enumberation_file_dialog->add_filter(TTR("*.mjs;JavaScript file"));
-	enumberation_file_dialog->set_current_file("enumerations.mjs");
 	enumberation_file_dialog->connect("file_selected", callable_mp(this, &JavaScriptPlugin::_export_enumeration_binding_file));
 	EditorNode::get_singleton()->get_gui_base()->add_child(enumberation_file_dialog);
 


### PR DESCRIPTION
## Description

closes #184

We can't prefill the `LineEdit` inside the `EditorFileDialog`, because it isn't inside the viewport when starting the editor.
Removed the prefills to solve error.

Make sure to follow the PR preparation steps in [CONTRIBUTING.md](https://github.com/Geequlim/ECMAScript/blob/master/CONTRIBUTING.md#preparing-your-pr) before submitting your PR:

- [x] format the codebase: from the root, run `bash ./clang_format.sh`.
